### PR TITLE
Prepare for Palace to maintain a project copy of webpub-viwer. (PP-888)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Publish Release
+
+on:
+  # The build will be triggered when we publish a release.
+  release:
+    types: [published]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - uses: actions/checkout@v4
+
+    - id: nvmrc
+      run: echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_OUTPUT
+
+    - name: Install Node.js 💻
+      uses: actions/setup-node@v4
+      with:
+        node-version: "${{ steps.nvmrc.outputs.NODE_VERSION }}"
+        registry-url: https://registry.npmjs.org/
+
+    - name: Install locked dependencies 🔧
+      run: npm clean-install
+
+    - name: Version ✅
+      run: npm version --no-git-tag-version ${{ github.event.release.tag_name }}
+
+    - name: Test 🧪
+      run: npm test
+
+    - name: Publish 📚
+      run: npm publish --access public
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Test
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    # We want to run on external PRs, but not on our own internal PRs as they'll be run
+    # by the push to the branch. This prevents duplicated runs on internal PRs.
+    # Some discussion of this here:
+    # https://github.community/t/duplicate-checks-on-push-and-pull-request-simultaneous-event/18012
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+
+      - id: nvmrc
+        run: echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_OUTPUT
+
+      - name: Install Node.js 💻
+        uses: actions/setup-node@v4
+        with:
+          node-version: "${{ steps.nvmrc.outputs.NODE_VERSION }}"
+
+      - name: Install locked dependencies 🔧
+        run: npm clean-install
+
+      - name: Test 🧪
+        run: npm test

--- a/README.md
+++ b/README.md
@@ -1,7 +1,22 @@
-# Deprecated
+# Web Publication Viewer
 
-As of July 2023, this app is no longer in use at NYPL, and the current implementation is https://github.com/NYPL-Simplified/web-reader. Please contact the eReading team in Digital for more information. For NYPL developers, please see additional documentation on [Confluence](https://confluence.nypl.org/display/DIGTL/Webreader).
+This is a [LYRASIS](http://lyrasis.org)-maintained fork of the deprecated NYPL [Library Simplified](http://www.librarysimplified.org/) `webpub-viewer` library.
 
 ## webpub-viewer
 
 A viewer application for web publications, based on Hadrien Gardeur's proof of concept https://github.com/HadrienGardeur/webpub-viewer.
+
+
+```
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/package.json
+++ b/package.json
@@ -1,9 +1,11 @@
 {
-  "name": "nypl-simplified-webpub-viewer",
-  "version": "0.0.4",
-  "author": "NYPL",
+  "name": "@thepalaceproject/webpub-viewer",
   "description": "A viewer application for web publications.",
-  "repository": "https://github.com/NYPL-Simplified/webpub-viewer.git",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/ThePalaceProject/webpub-viewer.git"
+  },
+  "author": "The Palace Project",
   "license": "Apache-2.0",
   "main": "dist/src/index.js",
   "typings": "dist/src/index.ts",


### PR DESCRIPTION
## Description

Set up `webpub-viewer` to be maintained as a local copy by The Palace Project.
- Updates README.
- Updates Node project name and repository.
- Adds GitHub Actions workflows.

## Motivation and Context

As part of moving [web-patron](https://github.com/ThePalaceProject/web-patron/settings) to Node 18, we needed to update incompatible dependencies on the `webpub-viewer` package, which is itself a dependency of `web-patron`. Unfortunately, this package is no longer supported by the original maintainer.

[Jira [PP-888](https://ebce-lyrasis.atlassian.net/browse/PP-888)]

[PP-888]: https://ebce-lyrasis.atlassian.net/browse/PP-888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ